### PR TITLE
Update README formatting by removing unnecessary blank line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # JBeacon
----
 
 ## Overview
 JBeacon is a <b>Java network polling library</b> implemented using the Java NIO package. JBeacon supports blocking & non-blocking network polling at a consistent rate using the ScheduledExecutorService.


### PR DESCRIPTION
The change removes an extra blank line between the title and the overview section. This improves the formatting and adheres to a cleaner markdown structure. No content was altered in this update.